### PR TITLE
Use Rayon for data parallelism!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ rustc-hash = "1.0"
 lazy_static = "1.0"
 edit-distance = "2.0"
 rupantor = "0.2"
+rayon = "1.0"
+hashbrown = { version = "0.4", features = ["rayon", "serde"] }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -45,8 +45,7 @@ pub(crate) fn get_modifiers(modifier: u8) -> Modifiers {
 
 #[macro_export]
 /// A helper macro for initializing HashMap.
-/// Originally from the `maplit` crate but customized for use
-/// with HashMap associated with `FxHasher`.
+/// Originally from the `maplit` crate but customized for use with `hashbrown::HashMap`.
 macro_rules! hashmap {
     (@single $($x:tt)*) => (());
     (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));
@@ -55,7 +54,7 @@ macro_rules! hashmap {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = hashmap!(@count $($key),*);
-            let mut _map = std::collections::HashMap::with_capacity_and_hasher(_cap, std::hash::BuildHasherDefault::<rustc_hash::FxHasher>::default());
+            let mut _map = hashbrown::HashMap::with_capacity(_cap);
             $(
                 let _ = _map.insert($key, $value);
             )*


### PR DESCRIPTION
Here we use [rayon](https://github.com/rayon-rs/rayon) for parallelism of dictionary searching of phonetic suggestion code. I have done the benchmarks and got 1.20x speedups!

```
name           old ns/iter  new ns/iter  diff ns/iter   diff %  speedup 
bench_a        456,249      361,669           -94,580  -20.73%   x 1.26 
bench_aro      537,914      461,900           -76,014  -14.13%   x 1.16 
bench_bistari  716,478      598,755          -117,723  -16.43%   x 1.20
```
For getting better support of rayon, we use the [`hashbrown`'s `HashMap`](https://github.com/rust-lang/hashbrown). But I am not using it in other places because it'll be the default HashMap implementation of the Rust standard library. So we'll get them free in next Rust versions.